### PR TITLE
Cloud-only LSF and a few fixes

### DIFF
--- a/LSF_On_IBM_Cloud/cloud_only.yml
+++ b/LSF_On_IBM_Cloud/cloud_only.yml
@@ -1,0 +1,153 @@
+---
+# -----------------------------------
+#  Copyright IBM Corp. 2020. All rights reserved.
+#  US Government Users Restricted Rights - Use, duplication or disclosure
+#  restricted by GSA ADP Schedule Contract with IBM Corp.
+# -----------------------------------
+
+# necessary workaround for fact-gathering issue:
+# ansible doesn't collect facts when running with a tag
+# that's only inside a role
+# see: https://github.com/ansible/ansible/issues/57529
+- hosts: "{{ansible_play_hosts}}"
+
+- name: VPN Connection Cleanup
+  hosts: localhost
+  roles:
+    - { role: disconnect_vpn, tags: disconnect_vpn }
+  tags:
+    - never
+    - clean_vpn
+
+# - name: static compute cleanup
+#   hosts: master,worker
+#   roles:
+#     - { role: clean_nfs_clnt, tags: clean_nfs_clnt }
+#     - { role: clean_compute, tags: clean_compute }
+#   tags:
+#     - cleanup
+
+# - name: Static master cleanup
+#   hosts: master
+#   roles:
+#     - { role: clean_nfs_clnt, tags: clean_nfs_clnt }
+#     - { role: clean_master, tags: clean_master }
+#   tags:
+#     - cleanup
+
+# - name: deployer cleanup
+#   hosts: deployer
+#   roles:
+#     - { role: clean_deployer, tags: clean_deployer }
+#   tags:
+#     - cleanup
+
+- name: local cleanup
+  hosts: localhost
+  roles:
+    - { role: clean_ssh_keypair, tags: clean_ssh_keypair }
+  tags:
+    - cleanup
+
+
+
+
+- name: ssh key-pair preparation
+  hosts: localhost
+  roles:
+    - { role: config_ssh_keypair,
+        tags: [config_ssh_keypair] }
+  tags:
+    - setup
+
+- name: deployer prep and configuration
+  hosts: deployer
+  roles:
+    - { role: prep_deployer,
+        tags: [prep_deployer,restart_master] }
+    - { role: config_deployer,
+        tags: config_deployer }
+  tags:
+    - setup
+
+- name: master prep
+  hosts: master
+  roles:
+    - { role: config_nfs_clnt,
+        tags: [config_nfs_clnt,restart_master] }
+    - { role: config_lsf_nodes,
+        tags: [config_lsf_nodes] }
+    - { role: prep_master,
+        tags: prep_master }
+  tags:
+    - setup
+
+- name: worker prep
+  hosts: worker
+  roles:
+    - { role: config_nfs_clnt,
+        tags: [config_nfs_clnt,restart_worker] }
+    - { role: config_lsf_nodes,
+        tags: config_lsf_nodes }
+    - { role: prep_worker,
+        tags: prep_worker }
+  tags:
+    - setup
+
+- name: deployer installs LSF
+  hosts: deployer
+  roles:
+    - { role: install_lsf,
+        tags: install_lsf }
+  tags:
+    - setup
+
+- name: configure LSF hosts
+  hosts: master,worker
+  roles:
+    - { role: restart_lsf,
+        tags: [restart_lsf,restart_worker,restart_master] }
+    - { role: post_install_nodes,
+        tags: [post_install_nodes,restart_worker] }
+    - { role: create_new_users,
+        tags: create_new_users }
+  tags:
+    - setup
+
+
+- name: Summary
+  hosts: localhost
+  gather_facts: no
+  tasks:
+    - debug:
+        msg:
+          - "LSF deployment completed on: {{ groups['compute'] }}"
+          - "Check the deployer_ansible.log file copied from {{ groups['master'][0] }} {{ hostvars[groups['master'][0]]['ansible_hostname'] }} to make sure everything went okay"
+  tags:
+    - setup
+
+- name: VPN Connection
+  hosts: localhost
+  roles:
+    - { role: connect_vpn, tags: connect_vpn }
+  tags:
+    - never
+    - vpn
+
+
+# Alternative VPN using OpenVPN
+- name: Cleanup OpenVPN
+  hosts: localhost
+  roles:
+    - { role: disconnect_open_vpn, tags: disconnect_open_vpn }
+  tags:
+    - never
+    - disconnect_open_vpn
+
+- name: OpenVPN setup
+  hosts: localhost
+  roles:
+    - { role: open_vpn, tags: open_vpn }
+  tags:
+    - never
+    - open_vpn

--- a/LSF_On_IBM_Cloud/group_vars/lsf_install
+++ b/LSF_On_IBM_Cloud/group_vars/lsf_install
@@ -43,6 +43,12 @@ multicluster:
   # role enable_users will create a cloud-side home in existing NFS mount
   lsf_user_list: []
 
+cloud_only:
+  # list of users to be created on the cloud lsf cluster
+  # role create_new_users will create a cloud-side home in existing NFS mount and generate ssh-keys
+  # the private keys will be downloaded to the executing host to provide to users for login
+  lsf_user_list: [alice, bob, coffee, donut]
+  lsf_user_group: lsfusers
 
 
 vpn:

--- a/LSF_On_IBM_Cloud/roles/create_new_users/tasks/main.yml
+++ b/LSF_On_IBM_Cloud/roles/create_new_users/tasks/main.yml
@@ -1,0 +1,118 @@
+---
+# -----------------------------------
+#  Copyright IBM Corp. 2020. All rights reserved.
+#  US Government Users Restricted Rights - Use, duplication or disclosure
+#  restricted by GSA ADP Schedule Contract with IBM Corp.
+# -----------------------------------
+
+- include_tasks: "../../common/tasks/get_files_dir.yml"
+  when: gen_files_dir is undefined or gen_files_dir == ""
+
+
+
+- name: "Creating group: {{cloud_only.lsf_user_group}}"
+  group:
+    name: "{{cloud_only.lsf_user_group}}"
+    gid: "1500"
+  become: yes
+
+- name: "Creating users"
+  user:
+    name: "{{item}}"
+    create_home: True
+    home: "{{nfs_mnt_dir}}/home/{{item}}"
+    uid: "{{idx|int + 1500}}"
+    group: "{{cloud_only.lsf_user_group}}"
+#        local: yes
+    shell: "/bin/bash"
+    generate_ssh_key: yes
+  become: yes
+  loop: "{{cloud_only.lsf_user_list}}"
+  loop_control:
+    index_var: idx
+
+- name: "Create local sshkey directory"
+  file:
+    path: "{{gen_files_dir}}/userkeys"
+    state: directory
+  delegate_to: localhost
+  run_once: yes
+
+- name: "Fetch private ssh key for users to log in"
+  fetch:
+    src: "{{nfs_mnt_dir}}/home/{{item}}/.ssh/id_rsa"
+    flat: yes
+    dest: "{{gen_files_dir}}/userkeys/id_rsa_{{item}}"
+  loop: "{{cloud_only.lsf_user_list}}"
+  become: yes
+  when: inventory_hostname == hostvars[ groups['master'][0]]['inventory_hostname']
+  run_once: yes
+
+- name: "Fetch public ssh key for users"
+  fetch:
+    src: "{{nfs_mnt_dir}}/home/{{item}}/.ssh/id_rsa.pub"
+    flat: yes
+    dest: "{{gen_files_dir}}/userkeys/id_rsa_{{item}}.pub"
+  loop: "{{cloud_only.lsf_user_list}}"
+  become: yes
+  when: inventory_hostname == hostvars[ groups['master'][0]]['inventory_hostname']
+  run_once: yes
+
+- name: "Need to adjust file permissions since fetch can mess that up"
+  file:
+    path: "{{gen_files_dir}}/userkeys/id_rsa_{{item}}"
+    mode: u+rw,go-rwx
+  loop: "{{cloud_only.lsf_user_list}}"
+  delegate_to: localhost
+  run_once: yes
+
+- name: "Add to authorized keys"
+  authorized_key:
+    user: "{{item}}"
+    state: present
+    key: "{{lookup('file',gen_files_dir+'/userkeys/id_rsa_'+item+'.pub')}}"
+  loop: "{{cloud_only.lsf_user_list}}"
+  become: yes
+
+
+
+
+- name: "Keyscan workers and masters"
+  command: "ssh-keyscan -tecdsa {{item}}"
+  loop: "{{groups['worker'] + groups['master']}}"
+  register: host_key_output
+  when: host_keys is undefined
+  run_once: yes
+
+- set_fact:
+    host_keys: "{{host_key_output.results|json_query('[*].{host: item,
+                                        key: stdout }')}}"
+  when: host_keys is undefined
+
+- name: "Set known_hosts for first user"
+  known_hosts:
+    key: "{{ item.key }}"
+    name: "{{ item.host }}"
+    state: present
+  loop: "{{host_keys}}"
+  no_log: true
+  become: yes
+  become_user: "{{cloud_only.lsf_user_list[0]}}"
+  run_once: yes
+
+- name: "Fetch the known_hosts file for distribution"
+  fetch:
+    src: "{{nfs_mnt_dir}}/home/{{cloud_only.lsf_user_list[0]}}/.ssh/known_hosts"
+    flat: yes
+    dest: "{{gen_files_dir}}/userkeys/known_hosts"
+  run_once: yes
+
+- name: "Create known_hosts file for all users"
+  copy:
+    src: "{{gen_files_dir}}/userkeys/known_hosts"
+    dest: "{{nfs_mnt_dir}}/home/{{item}}/.ssh/known_hosts"
+    owner: "{{item}}"
+    group: "{{cloud_only.lsf_user_group}}"
+    mode: u+rw,go-rwx
+  loop: "{{cloud_only.lsf_user_list}}"
+  run_once: yes

--- a/LSF_On_IBM_Cloud/roles/disconnect_open_vpn/tasks/main.yml
+++ b/LSF_On_IBM_Cloud/roles/disconnect_open_vpn/tasks/main.yml
@@ -37,15 +37,15 @@
 - name: "Template the setup script"
   vars:
     setup_type: "master"
-    purge: 0
+    purge: 1
   template:
-    src: "vpn_setup.sh.j2"
+    src: "../../open_vpn/templates/vpn_setup.sh.j2"
     dest: "{{gen_files_dir}}/scripts/setup.sh"
     mode: u=rwx,go=rx
 
 - name: "Upload remaining scripts"
   copy:
-    src: "{{item}}"
+    src: "../../open_vpn/files/{{item}}"
     dest: "{{gen_files_dir}}/scripts/{{item}}"
     mode: preserve
   loop:

--- a/LSF_On_IBM_Cloud/roles/enable_users/tasks/main.yml
+++ b/LSF_On_IBM_Cloud/roles/enable_users/tasks/main.yml
@@ -47,7 +47,24 @@
   user:
     name: "{{item}}"
     home: "{{nfs_mnt_dir}}/home/{{item}}"
-    move_home: yes
-  when: inventory_hostname != hostvars[ groups['master'][0]]['inventory_hostname']
+    generate_ssh_key: yes
+  loop: "{{multicluster.lsf_user_list}}"
+  become: yes
+
+- name: Authorize cloud-side ssh keys
+  command:
+    argv:
+      - cp
+      - "{{nfs_mnt_dir}}/home/{{item}}/.ssh/id_rsa.pub"
+      - "{{nfs_mnt_dir}}/home/{{item}}/.ssh/authorized_keys"
+    creates: "{{nfs_mnt_dir}}/home/{{item}}/.ssh/authorized_keys"
+  loop: "{{multicluster.lsf_user_list}}"
+  become: yes
+
+- name: Check/correct permissions on authorized_key file
+  file:
+    path: "{{nfs_mnt_dir}}/home/{{item}}/.ssh/authorized_keys"
+    owner: "{{item}}"
+    mode: u=rw,go=r
   loop: "{{multicluster.lsf_user_list}}"
   become: yes

--- a/LSF_On_IBM_Cloud/roles/open_vpn/files/vpn_functions.sh
+++ b/LSF_On_IBM_Cloud/roles/open_vpn/files/vpn_functions.sh
@@ -70,7 +70,7 @@ SERVER_SYSTEMD_SERVICE="/etc/systemd/system/openvpn-server.service"
 SERVER_IPTABLES_SCRIPT="/root/iptables-server.sh"
 SERVER_TARFILE="/root/server.tgz"
 SERVER_TEMPDIR="/tmp/server"
-SERVER_PKGS="openvpn emacs"
+SERVER_PKGS="openvpn"
 # VPN subnet and mask default
 vpn_cidr="" # 10.8.0.0/24" #    TODO
 # VPC subnet and mask must be provided
@@ -90,7 +90,7 @@ CLIENT_SYSTEMD_SERVICE="/etc/systemd/system/openvpn-client.service"
 CLIENT_IPTABLES_SCRIPT="/root/iptables-client.sh"
 CLIENT_TEMPDIR="/tmp/client"
 CLIENT_TARFILE="/root/client.tgz"
-CLIENT_PKGS="openvpn easy-rsa emacs"
+CLIENT_PKGS="openvpn easy-rsa"
 
 validate_settings() {
     local func="${FUNCNAME[0]}()"

--- a/LSF_On_IBM_Cloud/roles/open_vpn/templates/vpn_setup.sh.j2
+++ b/LSF_On_IBM_Cloud/roles/open_vpn/templates/vpn_setup.sh.j2
@@ -40,7 +40,7 @@ debug=${debug:-2} # better be 1
 certs=${certs:-1} # must be 1
 setup=${setup:-1} # run actual setup
 execute=${execute:-1} # execute the openvpn binary
-purge=${purge:-0} # purge installation
+purge=${purge:-{{purge}}} # purge installation
 yum=${yum:-1}     # must be 1
 rpm=${rpm:-1}     # suggested to be 1
 
@@ -53,7 +53,7 @@ vpn_cidr='{{vpn_cn.ovpn_cidr}}' # cidr of the VPN
 ibm_cidr='{{vpn_cn.peer_cidrs[0]}}' # cidr of the on-prem subnet
 ssh_config='{{gen_files_dir}}/ssh_config'   # ssh config file from the terraform generated VPC
 lsf_master='{{groups['master'][0]}}'  # IP address of the VPC's master
-setup_type=${setup_type:-"master"} # either master or login
+setup_type=${setup_type:-"{{setup_type}}"} # either master or login
 
 # combine all args to pass to all steps at once
 opt="--settings --verbose ${verbose} --debug ${debug} --certs ${certs} --purge ${purge} --yum ${yum} --rpm ${rpm} --floating_ip ${floating_ip} --onprem_node ${onprem_node} --client_nic ${client_nic} --vpc_cidr ${vpc_cidr} --vpn_cidr ${vpn_cidr} --ibm_cidr ${ibm_cidr} --ssh_config ${ssh_config} --lsf_master ${lsf_master} --setup_type ${setup_type}"
@@ -98,8 +98,10 @@ ssh root@${onprem_node} "./setup-client.sh ${opt} --setup 1 --execute 0"
 logInfo 1 "${this} RC:$? Execution of script on ${onprem_node}"
 
 # get server tar file from client
-scp root@${onprem_node}:server.tgz .
-logInfo 1 "${this} RC:$? retrieval of server.tgz from OpenVPN client as ${onprem_node}"
+if [[ ${purge} -eq 0 ]] ; then
+    scp root@${onprem_node}:server.tgz .
+    logInfo 1 "${this} RC:$? retrieval of server.tgz from OpenVPN client as ${onprem_node}"
+fi
 
 # choice: we use master for simplicity of VPN connection
 case ${setup_type} in

--- a/LSF_On_IBM_Cloud/static_cluster.yml
+++ b/LSF_On_IBM_Cloud/static_cluster.yml
@@ -164,12 +164,11 @@
 # Alternative VPN using OpenVPN
 - name: Cleanup OpenVPN
   hosts: localhost
-  tasks:
-    - debug:
-        msg: "ToBeDone"
+  roles:
+    - { role: disconnect_open_vpn, tags: disconnect_open_vpn }
   tags:
     - never
-    - clean_open_vpn
+    - disconnect_open_vpn
 
 - name: OpenVPN setup
   hosts: localhost


### PR DESCRIPTION
This PR:
 * adds a cloud_only playbook to only create/install the cloud-side LSF cluster without the requirement of an existing on-prem cluster and without the need to establish a VPN. This also automatically creates users including ssh-keys to enable login.

 * makes some corrections to the open_vpn alternative (especially the purge/cleanup options)

 * adds ssh-keys for the cloud-side users to simplify one more step of the configuration (it's currently not enabling passwordless access from on-prem to cloud because that would require to automatically reach into existing user home directories and make potential modifications)
