### PR TITLE
auto-detect lsfadmin home before uploading ssh keys

### DIFF
--- a/LSF_On_IBM_Cloud/roles/post_install_nodes/tasks/main.yml
+++ b/LSF_On_IBM_Cloud/roles/post_install_nodes/tasks/main.yml
@@ -13,10 +13,19 @@
     user: lsfadmin
     key: "{{ lookup('file', '{{ gen_files_dir }}/id_rsa.lsfadmin.pub') }}"
 
+- name: Detect lsfadmin home directory
+  getent:
+    database: passwd
+    key: lsfadmin
+  become: yes
+
+- set_fact:
+    lsfadmin_home: "{{getent_passwd.lsfadmin[4]}}"  # home dir is the 5th entry in the returned getent_passwd list
+
 - name: Copy id_rsa to lsfadmin ~/.ssh
   copy:
     src: "{{ gen_files_dir }}/id_rsa.lsfadmin"
-    dest: /opt/ibm/lsfsuite/.ssh/id_rsa
+    dest: "{{lsfadmin_home}}/.ssh/id_rsa"
     mode: "0600"
     owner: lsfadmin
     group: lsfadmin
@@ -26,7 +35,7 @@
 - name: Copy id_rsa.pub to lsfadmin ~/.ssh
   copy:
     src: "{{ gen_files_dir }}/id_rsa.lsfadmin.pub"
-    dest: /opt/ibm/lsfsuite/.ssh/id_rsa.pub
+    dest: "{{lsfadmin_home}}/.ssh/id_rsa.pub"
     owner: lsfadmin
     group: lsfadmin
     backup: yes


### PR DESCRIPTION
This PR fixes a problem with a hard-coded lsfadmin home directory. The hard-coded location caused this tool to fail for more recent versions of LSF (the home dir location has changed).

The approach is to read the homedir from the passwd database to auto-detect the location and then use it for the setup of things like the ssh key.